### PR TITLE
Sets a static width for chosen selects

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -32,6 +32,6 @@ $(document).on("ready turbolinks:load", function() {
     });
   }
 
-  $(".chzn-select").chosen();
+  $(".chzn-select").chosen({width: '100%'});
 
 });


### PR DESCRIPTION
The select elements on the hidden tabs of the schedule form have a width
of 0 on ready, so they don't work without a specified width.