### PR TITLE
Show what song is playing in the persistent player

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
         "exports": "always-multiline",
         "functions": "never"
       }
-    ]
+    ],
+    "no-duplicate-imports": 0
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,8 @@
         "functions": "never"
       }
     ],
-    "no-duplicate-imports": 0
+    "no-duplicate-imports": 0,
+    "no-undef": 0,
+    "react/prop-types": 0
   }
 }

--- a/.flowconfig
+++ b/.flowconfig
@@ -17,4 +17,4 @@ module.ignore_non_literal_requires=true
 [strict]
 
 [version]
-0.59.0
+0.61.0

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'dalli'
 gem 'kgio'
 gem 'rack-cache'
 # Queue
+gem 'redis', '~> 3.0'
 gem 'sidekiq'
 # Monitoring
 gem 'newrelic_rpm', group: :production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,7 +212,7 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redcarpet (3.4.0)
-    redis (4.0.1)
+    redis (3.3.5)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
     request_store (1.3.2)
@@ -362,6 +362,7 @@ DEPENDENCIES
   rails-latex
   rails_12factor
   redcarpet
+  redis (~> 3.0)
   resque
   resque-scheduler
   resque_mailer

--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -3,7 +3,6 @@
 //
 //= require action_cable
 //= require_self
-//= require_tree ./channels
 
 (function() {
   this.App || (this.App = {});

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -17,5 +17,6 @@
 
 @import url(https://fonts.googleapis.com/css?family=Alegreya+Sans:800,500,500italic,400italic,400|Alegreya+Sans+SC:700);
 @import url(https://fonts.googleapis.com/css?family=Merriweather:900,900italic);
-@import url(https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css)
+@import url(https://fonts.googleapis.com/css?family=Lato:400,400italic,700,700italic);
 
+@import url(https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css);

--- a/app/assets/stylesheets/playlist.css.scss
+++ b/app/assets/stylesheets/playlist.css.scss
@@ -43,6 +43,14 @@ tr.grey * { color: #999; }
 #now.dj-signed-in-now td { padding-top: 6em; }
 #now.dj-signed-out-now td { padding-top: 4em; }
 
+.refresh-playlist {
+  color: #999;
+}
+
+body:not(.playlist-needs-refresh) .refresh-playlist {
+  display: none;
+}
+
 i.dingbat {
   font-style: normal;
   font-family: "Zapf Dingbats";

--- a/app/channels/playlist_channel.rb
+++ b/app/channels/playlist_channel.rb
@@ -1,6 +1,8 @@
 class PlaylistChannel < ApplicationCable::Channel
   NAME = 'playlist_channel'.freeze
   SONG_CREATED_TYPE = 'song_created'.freeze
+  SONG_UPDATED_TYPE = 'song_updated'.freeze
+  SONG_DESTROYED_TYPE = 'song_destroyed'.freeze
 
   def subscribed
     transmit_now_playing_song

--- a/app/channels/playlist_channel.rb
+++ b/app/channels/playlist_channel.rb
@@ -1,0 +1,17 @@
+class PlaylistChannel < ApplicationCable::Channel
+  NAME = 'playlist_channel'.freeze
+  SONG_CREATED_TYPE = 'song_created'.freeze
+
+  def subscribed
+    transmit_now_playing_song
+    stream_from NAME
+  end
+
+  def unsubscribed; end
+
+  private
+
+  def transmit_now_playing_song
+    transmit type: SONG_CREATED_TYPE, song: Song.on_air
+  end
+end

--- a/app/javascript/channels/PlaylistChannel.jsx
+++ b/app/javascript/channels/PlaylistChannel.jsx
@@ -15,7 +15,7 @@ type SongUpdatedMessage = {| +type: 'song_updated', +song: Song |}
 type SongDestroyedMessage = {| +type: 'song_destroyed', +id: number |}
 type PlaylistChannelMessage =
   | SongCreatedMessage
-  | SongCreatedMessage
+  | SongUpdatedMessage
   | SongDestroyedMessage
 
 type State = {

--- a/app/javascript/channels/PlaylistChannel.jsx
+++ b/app/javascript/channels/PlaylistChannel.jsx
@@ -1,0 +1,48 @@
+/**
+ * @providesModule withPlaylistChannel
+ * @flow
+ */
+
+/* global App */
+
+import * as React from 'react'
+
+import { defaultSong } from 'models'
+import type { Song } from 'models'
+
+type SongCreatedMessage = {| +type: 'song_created', +song: Song |}
+type PlaylistChannelMessage = SongCreatedMessage // | OtherMessage
+
+type State = {
+  song: Song,
+}
+function withPlaylistChannel<Props: {}> (
+  Component: React.ComponentType<State & Props>
+): React.ComponentType<Props> {
+  class WrapperComponent extends React.Component<Props, State> {
+    state = { song: defaultSong }
+
+    componentDidMount () {
+      if (App == null) return
+      App.cable.subscriptions.create('PlaylistChannel', {
+        received: (message: PlaylistChannelMessage) => {
+          switch (message.type) {
+            case 'song_created':
+              this.setState({ song: message.song })
+          }
+        },
+      })
+    }
+
+    render () {
+      const { song } = this.state
+      return <Component {...this.props} song={song} />
+    }
+  }
+
+  WrapperComponent.displayName = `withPlaylistChannel(${Component.displayName ||
+    Component.name})`
+  return WrapperComponent
+}
+
+export default withPlaylistChannel

--- a/app/javascript/channels/PlaylistChannel.jsx
+++ b/app/javascript/channels/PlaylistChannel.jsx
@@ -41,6 +41,8 @@ function withPlaylistChannel<Props: {}> (
       if (App == null) return
       this.subscription = App.cable.subscriptions.create('PlaylistChannel', {
         received: (message: PlaylistChannelMessage) => {
+          this._setRefreshNeeded()
+
           switch (message.type) {
             case 'song_created':
               this.setState({ song: message.song })
@@ -64,6 +66,11 @@ function withPlaylistChannel<Props: {}> (
     _disconnect () {
       if (this.subscription == null) return
       this.subscription.unsubscribe()
+    }
+
+    _setRefreshNeeded () {
+      if (this.state.song.id == null) return
+      document.body && document.body.classList.add('playlist-needs-refresh')
     }
   }
 

--- a/app/javascript/channels/PlaylistChannel.jsx
+++ b/app/javascript/channels/PlaylistChannel.jsx
@@ -11,7 +11,12 @@ import { defaultSong } from 'models'
 import type { Song } from 'models'
 
 type SongCreatedMessage = {| +type: 'song_created', +song: Song |}
-type PlaylistChannelMessage = SongCreatedMessage // | OtherMessage
+type SongUpdatedMessage = {| +type: 'song_updated', +song: Song |}
+type SongDestroyedMessage = {| +type: 'song_destroyed', +id: number |}
+type PlaylistChannelMessage =
+  | SongCreatedMessage
+  | SongCreatedMessage
+  | SongDestroyedMessage
 
 type State = {
   song: Song,
@@ -20,23 +25,45 @@ function withPlaylistChannel<Props: {}> (
   Component: React.ComponentType<State & Props>
 ): React.ComponentType<Props> {
   class WrapperComponent extends React.Component<Props, State> {
+    subscription: ?ActionCable$Subscription
     state = { song: defaultSong }
 
     componentDidMount () {
-      if (App == null) return
-      App.cable.subscriptions.create('PlaylistChannel', {
-        received: (message: PlaylistChannelMessage) => {
-          switch (message.type) {
-            case 'song_created':
-              this.setState({ song: message.song })
-          }
-        },
-      })
+      this._connect()
     }
 
     render () {
       const { song } = this.state
       return <Component {...this.props} song={song} />
+    }
+
+    _connect () {
+      if (App == null) return
+      this.subscription = App.cable.subscriptions.create('PlaylistChannel', {
+        received: (message: PlaylistChannelMessage) => {
+          switch (message.type) {
+            case 'song_created':
+              this.setState({ song: message.song })
+              break
+
+            case 'song_updated':
+              if (this.state.song.id === message.song.id) {
+                this.setState({ song: message.song })
+              }
+              break
+
+            case 'song_destroyed':
+              this._disconnect()
+              this._connect()
+              break
+          }
+        },
+      })
+    }
+
+    _disconnect () {
+      if (this.subscription == null) return
+      this.subscription.unsubscribe()
     }
   }
 

--- a/app/javascript/models/Song.js
+++ b/app/javascript/models/Song.js
@@ -1,0 +1,28 @@
+/**
+ * @providesModule Song
+ * @flow
+ */
+
+export type Song = {
+  +name: string,
+  +artist: string,
+  +album: string,
+  +label: string,
+  +year: ?number,
+  +request: boolean,
+  +new: boolean,
+  +local: boolean,
+  +at: Date,
+}
+
+export const defaultSong: Song = {
+  name: '',
+  artist: '',
+  album: '',
+  label: '',
+  year: null,
+  request: false,
+  new: false,
+  local: false,
+  at: new Date(),
+}

--- a/app/javascript/models/Song.js
+++ b/app/javascript/models/Song.js
@@ -4,6 +4,7 @@
  */
 
 export type Song = {
+  +id: ?number,
   +name: string,
   +artist: string,
   +album: string,
@@ -16,6 +17,7 @@ export type Song = {
 }
 
 export const defaultSong: Song = {
+  id: null,
   name: '',
   artist: '',
   album: '',

--- a/app/javascript/models/index.js
+++ b/app/javascript/models/index.js
@@ -1,0 +1,5 @@
+/**
+ * @flow models
+ */
+
+export * from './Song'

--- a/app/javascript/packs/player.jsx
+++ b/app/javascript/packs/player.jsx
@@ -9,12 +9,15 @@ import { ThemeProvider } from 'styled-components'
 import theme from 'styled/theme'
 
 import Player from 'player'
+import withPlaylistChannel from 'channels/PlaylistChannel'
+
+const PlayerWithPlaylistChannel = withPlaylistChannel(Player)
 
 const container = document.getElementById('player-app')
 if (container) {
   render(
     <ThemeProvider theme={theme}>
-      <Player />
+      <PlayerWithPlaylistChannel />
     </ThemeProvider>,
     container
   )

--- a/app/javascript/player/AlbumArt.jsx
+++ b/app/javascript/player/AlbumArt.jsx
@@ -7,9 +7,11 @@ import * as React from 'react'
 import styled from 'styled-components'
 import { rgba } from 'polished'
 
+import ImageZoom from 'styled/ImageZoom'
+
 import type { Song } from 'models'
 
-const Image = styled.img.attrs({ role: 'presentation' })`
+const Image = styled(ImageZoom).attrs({ role: 'presentation' })`
   background-color: ${p => rgba(p.theme.white, 0.4)};
   width: 40px;
   height: 40px;
@@ -28,7 +30,12 @@ class AlbumArt extends React.Component<Props, State> {
 
   render () {
     if (this.state.imageSrc == null) return null
-    return <Image src={this.state.imageSrc} />
+    return (
+      <Image
+        image={{ src: this.state.imageSrc }}
+        zoomImage={{ src: this._largeImageSrc() }}
+      />
+    )
   }
 
   _getArtworkURL () {
@@ -40,6 +47,15 @@ class AlbumArt extends React.Component<Props, State> {
         const imageSrc = firstResult != null ? firstResult.artworkUrl100 : null
         this.setState({ imageSrc })
       })
+  }
+
+  /**
+   * The high-resolution image is lazy-loaded when the album art is zoomed in
+   */
+  _largeImageSrc () {
+    const { imageSrc } = this.state
+    if (imageSrc == null) return null
+    return imageSrc.replace(/100x100/, '1000x1000')
   }
 
   _queryURL () {

--- a/app/javascript/player/AlbumArt.jsx
+++ b/app/javascript/player/AlbumArt.jsx
@@ -1,0 +1,53 @@
+/**
+ * @providesModule AlbumArt
+ * @flow
+ */
+
+import * as React from 'react'
+import styled from 'styled-components'
+import { rgba } from 'polished'
+
+import type { Song } from 'models'
+
+const Image = styled.img.attrs({ role: 'presentation' })`
+  background-color: ${p => rgba(p.theme.white, 0.4)};
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  margin-right: 10px;
+`
+
+type Props = { song: Song }
+type State = { imageSrc: ?string }
+class AlbumArt extends React.Component<Props, State> {
+  state = { imageSrc: null }
+
+  componentDidUpdate (prevProps: Props) {
+    if (this.props.song !== prevProps.song) this._getArtworkURL()
+  }
+
+  render () {
+    if (this.state.imageSrc == null) return null
+    return <Image src={this.state.imageSrc} />
+  }
+
+  _getArtworkURL () {
+    fetch(this._queryURL())
+      .then(r => r.json())
+      .then(data => {
+        const { results } = data
+        const [firstResult] = results
+        const imageSrc = firstResult != null ? firstResult.artworkUrl100 : null
+        this.setState({ imageSrc })
+      })
+  }
+
+  _queryURL () {
+    const { album, artist } = this.props.song
+    return (
+      'https://itunes.apple.com/search?limit=1&version=2&entity=album&' +
+      `term=${encodeURIComponent(`${album} ${artist}`)}`
+    )
+  }
+}
+export default AlbumArt

--- a/app/javascript/player/PlayPauseButton.jsx
+++ b/app/javascript/player/PlayPauseButton.jsx
@@ -30,6 +30,8 @@ const Button = styled.button`
   box-shadow: none;
   background: transparent;
 
+  transition: background-color 0.7s ease;
+
   cursor: pointer;
 
   .tab-focus &:focus {

--- a/app/javascript/player/PlayPauseButton.jsx
+++ b/app/javascript/player/PlayPauseButton.jsx
@@ -7,6 +7,14 @@ import * as React from 'react'
 import styled, { css } from 'styled-components'
 import { rgba } from 'polished'
 
+const Container = styled.div`
+  background-color: ${props => props.theme.blue};
+  padding: 10px;
+  padding-right: 6px;
+
+  z-index: 1;
+`
+
 const Button = styled.button`
   width: 50px;
   height: 50px;
@@ -57,8 +65,10 @@ const Icon = styled.i.attrs({
 
 type Props = { onClick: (e: SyntheticMouseEvent<*>) => mixed, playing: boolean }
 const PlayPauseButton = ({ onClick, playing }: Props) => (
-  <Button onClick={onClick}>
-    <Icon playing={playing} />
-  </Button>
+  <Container>
+    <Button onClick={onClick}>
+      <Icon playing={playing} />
+    </Button>
+  </Container>
 )
 export default PlayPauseButton

--- a/app/javascript/player/PlayPauseButton.jsx
+++ b/app/javascript/player/PlayPauseButton.jsx
@@ -1,0 +1,64 @@
+/**
+ * @providesModule PlayPauseButton
+ * @flow
+ */
+
+import * as React from 'react'
+import styled, { css } from 'styled-components'
+import { rgba } from 'polished'
+
+const Button = styled.button`
+  width: 50px;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  color: ${p => p.theme.white};
+  text-shadow: none;
+
+  border: none;
+  border-radius: 50%;
+  box-shadow: none;
+  background: transparent;
+
+  cursor: pointer;
+
+  .tab-focus &:focus {
+    border: 1px solid ${p => rgba(p.theme.white, 0.4)};
+    background: ${p => rgba(p.theme.white, 0.15)};
+  }
+
+  &:hover {
+    background: ${p => rgba(p.theme.white, 0.15)};
+  }
+
+  &:active {
+    box-shadow: none;
+    background: ${p => rgba(p.theme.white, 0.3)};
+  }
+
+  &:focus {
+    box-shadow: none;
+  }
+`
+
+const Icon = styled.i.attrs({
+  'aria-label': p =>
+    p.playing ? 'Stop radio playback.' : 'Listen to the radio.',
+  className: p => `fa fa-2x fa-${p.playing ? 'pause' : 'play'}`,
+})`
+  ${p =>
+    p.playing ||
+    css`
+      margin-left: 4px; /* to make the play button visually centered */
+    `};
+`
+
+type Props = { onClick: (e: SyntheticMouseEvent<*>) => mixed, playing: boolean }
+const PlayPauseButton = ({ onClick, playing }: Props) => (
+  <Button onClick={onClick}>
+    <Icon playing={playing} />
+  </Button>
+)
+export default PlayPauseButton

--- a/app/javascript/player/SongInformation.jsx
+++ b/app/javascript/player/SongInformation.jsx
@@ -22,10 +22,13 @@ const Container = styled.div`
 `
 
 const InfoBox = styled.div`
+  max-width: 700px;
+  max-height: 60px;
   padding: 0 15px;
   border-left: 1px solid ${p => rgba(p.theme.white, 0.4)};
   display: flex;
-  align-items: center;
+  align-items: flex-start;
+  overflow: hidden;
 `
 
 type Props = { song: Song, visible: boolean }

--- a/app/javascript/player/SongInformation.jsx
+++ b/app/javascript/player/SongInformation.jsx
@@ -7,32 +7,52 @@ import * as React from 'react'
 import styled from 'styled-components'
 import { rgba } from 'polished'
 
+import { Motion, spring } from 'react-motion'
+
 import type { Song } from 'models'
 
 const Container = styled.div`
+  padding-left: 4px;
+  background-color: ${props => props.theme.blue};
+  border-top-right-radius: 4px;
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  margin-left: 10px;
-  padding: 0 5px 0 15px;
+  align-items: center;
+`
+
+const TextBox = styled.div`
+  padding: 0 15px;
   border-left: 1px solid ${p => rgba(p.theme.white, 0.4)};
 `
 
-type Props = { song: Song }
-const SongInformation = ({ song }: Props) => {
+type Props = { song: Song, visible: boolean }
+const SongInformation = ({ song, visible }: Props) => {
   const { artist, name, album, label, year } = song
   return (
-    <Container>
-      <strong>
-        {artist && `${artist}: `}
-        “{name}”
-      </strong>
-      <span>
-        <cite>{album}</cite>
-        {(label || year != null) &&
-          ` (${label}${label && year ? ' ' : ''}${year || ''})`}
-      </span>
-    </Container>
+    <Motion style={{ x: spring(visible ? 0 : 1) }}>
+      {({ x }) => (
+        <Container
+          style={{
+            transform: `translate(calc(${x * -100}% + ${x * 4}px))`,
+          }}
+        >
+          <TextBox>
+            <div>
+              <strong>
+                {artist && `${artist}: `}
+                “{name}”
+              </strong>
+            </div>
+            <div>
+              <span>
+                <cite>{album}</cite>
+                {(label || year != null) &&
+                  ` (${label}${label && year ? ' ' : ''}${year || ''})`}
+              </span>
+            </div>
+          </TextBox>
+        </Container>
+      )}
+    </Motion>
   )
 }
 export default SongInformation

--- a/app/javascript/player/SongInformation.jsx
+++ b/app/javascript/player/SongInformation.jsx
@@ -9,6 +9,8 @@ import { rgba } from 'polished'
 
 import { Motion, spring } from 'react-motion'
 
+import AlbumArt from './AlbumArt'
+
 import type { Song } from 'models'
 
 const Container = styled.div`
@@ -19,9 +21,11 @@ const Container = styled.div`
   align-items: center;
 `
 
-const TextBox = styled.div`
+const InfoBox = styled.div`
   padding: 0 15px;
   border-left: 1px solid ${p => rgba(p.theme.white, 0.4)};
+  display: flex;
+  align-items: center;
 `
 
 type Props = { song: Song, visible: boolean }
@@ -35,21 +39,24 @@ const SongInformation = ({ song, visible }: Props) => {
             transform: `translate(calc(${x * -100}% + ${x * 4}px))`,
           }}
         >
-          <TextBox>
+          <InfoBox>
+            <AlbumArt song={song} />
             <div>
-              <strong>
-                {artist && `${artist}: `}
-                “{name}”
-              </strong>
+              <div>
+                <strong>
+                  {artist && `${artist}: `}
+                  “{name}”
+                </strong>
+              </div>
+              <div>
+                <span>
+                  <cite>{album}</cite>
+                  {(label || year != null) &&
+                    ` (${label}${label && year ? ' ' : ''}${year || ''})`}
+                </span>
+              </div>
             </div>
-            <div>
-              <span>
-                <cite>{album}</cite>
-                {(label || year != null) &&
-                  ` (${label}${label && year ? ' ' : ''}${year || ''})`}
-              </span>
-            </div>
-          </TextBox>
+          </InfoBox>
         </Container>
       )}
     </Motion>

--- a/app/javascript/player/SongInformation.jsx
+++ b/app/javascript/player/SongInformation.jsx
@@ -1,0 +1,38 @@
+/**
+ * @providesModule SongInformation
+ * @flow
+ */
+
+import * as React from 'react'
+import styled from 'styled-components'
+import { rgba } from 'polished'
+
+import type { Song } from 'models'
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin-left: 10px;
+  padding: 0 5px 0 15px;
+  border-left: 1px solid ${p => rgba(p.theme.white, 0.4)};
+`
+
+type Props = { song: Song }
+const SongInformation = ({ song }: Props) => {
+  const { artist, name, album, label, year } = song
+  return (
+    <Container>
+      <strong>
+        {artist && `${artist}: `}
+        “{name}”
+      </strong>
+      <span>
+        <cite>{album}</cite>
+        {(label || year != null) &&
+          ` (${label}${label && year ? ' ' : ''}${year || ''})`}
+      </span>
+    </Container>
+  )
+}
+export default SongInformation

--- a/app/javascript/player/index.jsx
+++ b/app/javascript/player/index.jsx
@@ -4,8 +4,9 @@
  */
 
 import * as React from 'react'
-import styled, { css } from 'styled-components'
-import { rgba } from 'polished'
+import styled from 'styled-components'
+
+import PlayPauseButton from './PlayPauseButton'
 
 import type { Song } from 'models'
 
@@ -20,54 +21,6 @@ const Container = styled.div`
   display: flex;
 
   border-top-right-radius: 4px;
-`
-
-const PlayPauseButton = styled.button`
-  width: 50px;
-  height: 50px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  color: ${p => p.theme.white};
-  text-shadow: none;
-
-  border: none;
-  border-radius: 50%;
-  box-shadow: none;
-  background: transparent;
-
-  cursor: pointer;
-
-  .tab-focus &:focus {
-    border: 1px solid ${p => rgba(p.theme.white, 0.4)};
-    background: ${p => rgba(p.theme.white, 0.15)};
-  }
-
-  &:hover {
-    background: ${p => rgba(p.theme.white, 0.15)};
-  }
-
-  &:active {
-    box-shadow: none;
-    background: ${p => rgba(p.theme.white, 0.3)};
-  }
-
-  &:focus {
-    box-shadow: none;
-  }
-`
-
-const PlayPauseIcon = styled.i.attrs({
-  'aria-label': p =>
-    p.playing ? 'Stop radio playback.' : 'Listen to the radio.',
-  className: p => `fa fa-2x fa-${p.playing ? 'pause' : 'play'}`,
-})`
-  ${p =>
-    p.playing ||
-    css`
-      margin-left: 4px; /* to make the play button visually centered */
-    `};
 `
 
 function drupalLinks (): NodeList<HTMLAnchorElement> {
@@ -107,9 +60,7 @@ class Player extends React.Component<Props, { playing: boolean }> {
     const { playing } = this.state
     return (
       <Container>
-        <PlayPauseButton onClick={this.handlePlayPause}>
-          <PlayPauseIcon playing={playing} />
-        </PlayPauseButton>
+        <PlayPauseButton playing={playing} onClick={this.handlePlayPause} />
       </Container>
     )
   }

--- a/app/javascript/player/index.jsx
+++ b/app/javascript/player/index.jsx
@@ -7,6 +7,7 @@ import * as React from 'react'
 import styled from 'styled-components'
 
 import PlayPauseButton from './PlayPauseButton'
+import SongInformation from './SongInformation'
 
 import type { Song } from 'models'
 
@@ -19,6 +20,9 @@ const Container = styled.div`
   background-color: ${props => props.theme.blue};
   padding: 10px;
   display: flex;
+
+  color: ${props => props.theme.white};
+  font-family: 'Lato';
 
   border-top-right-radius: 4px;
 `
@@ -57,10 +61,12 @@ class Player extends React.Component<Props, { playing: boolean }> {
   }
 
   render () {
+    const { song } = this.props
     const { playing } = this.state
     return (
       <Container>
         <PlayPauseButton playing={playing} onClick={this.handlePlayPause} />
+        {playing && <SongInformation song={song} />}
       </Container>
     )
   }

--- a/app/javascript/player/index.jsx
+++ b/app/javascript/player/index.jsx
@@ -17,14 +17,11 @@ const Container = styled.div`
   position: fixed;
   bottom: 0;
   left: 0;
-  background-color: ${props => props.theme.blue};
-  padding: 10px;
   display: flex;
+  align-items: stretch;
 
   color: ${props => props.theme.white};
   font-family: 'Lato';
-
-  border-top-right-radius: 4px;
 `
 
 function drupalLinks (): NodeList<HTMLAnchorElement> {
@@ -66,7 +63,7 @@ class Player extends React.Component<Props, { playing: boolean }> {
     return (
       <Container>
         <PlayPauseButton playing={playing} onClick={this.handlePlayPause} />
-        {playing && <SongInformation song={song} />}
+        <SongInformation visible={playing} song={song} />
       </Container>
     )
   }

--- a/app/javascript/player/index.jsx
+++ b/app/javascript/player/index.jsx
@@ -57,6 +57,13 @@ class Player extends React.Component<Props, { playing: boolean }> {
     this.audioElement = document.createElement('audio')
   }
 
+  componentDidMount () {
+    const Url = new URL(window.location.href)
+    if (Url.searchParams.get('autoplay') === 'true') {
+      this._play()
+    }
+  }
+
   render () {
     const { song } = this.props
     const { playing } = this.state

--- a/app/javascript/player/index.jsx
+++ b/app/javascript/player/index.jsx
@@ -58,8 +58,8 @@ class Player extends React.Component<Props, { playing: boolean }> {
   }
 
   componentDidMount () {
-    const Url = new URL(window.location.href)
-    if (Url.searchParams.get('autoplay') === 'true') {
+    const url = new URL(window.location)
+    if (url.searchParams.has('autoplay')) {
       this._play()
     }
   }

--- a/app/javascript/player/index.jsx
+++ b/app/javascript/player/index.jsx
@@ -7,6 +7,8 @@ import * as React from 'react'
 import styled, { css } from 'styled-components'
 import { rgba } from 'polished'
 
+import type { Song } from 'models'
+
 const WCBN_HD_STREAM_URL = 'http://floyd.wcbn.org:8000/wcbn-hd.mp3'
 
 const Container = styled.div`
@@ -90,11 +92,12 @@ function removeTargetBlankFromDrupalLinks () {
   })
 }
 
-class Player extends React.Component<{}, { playing: boolean }> {
+type Props = { song: Song }
+class Player extends React.Component<Props, { playing: boolean }> {
   audioElement: HTMLAudioElement
   state = { playing: false }
 
-  constructor (props: {}) {
+  constructor (props: Props) {
     super(props)
 
     this.audioElement = document.createElement('audio')

--- a/app/javascript/styled/ImageZoom.jsx
+++ b/app/javascript/styled/ImageZoom.jsx
@@ -1,0 +1,20 @@
+/**
+ * @providesModule ImageZoom
+ * @flow
+ */
+
+import * as React from 'react'
+import BaseImageZoom from 'react-medium-image-zoom'
+
+/**
+ * The react-medium-image-zoom component is great, but doesn’t support being
+ * styled with styled-components. This shim passes the className given it by
+ * styled-components into the image props object that react-medium-image-zoom
+ * expects from us.
+ */
+
+type Props = { className: string, image: { [string]: string } }
+const ImageZoom = ({ className, image, ...rest }: Props) => (
+  <BaseImageZoom image={{ ...image, className }} {...rest} />
+)
+export default ImageZoom

--- a/app/jobs/song_broadcast_job.rb
+++ b/app/jobs/song_broadcast_job.rb
@@ -3,7 +3,23 @@ class SongBroadcastJob < ApplicationJob
 
   def perform(song)
     ActionCable.server.broadcast PlaylistChannel::NAME,
-                                 type: PlaylistChannel::SONG_CREATED_TYPE,
+                                 type: type(song),
                                  song: song
+  end
+  
+  rescue_from ActiveJob::DeserializationError do |exception|
+    ActionCable.server.broadcast PlaylistChannel::NAME,
+                                 type: PlaylistChannel::SONG_DESTROYED_TYPE,
+                                 id: exception.cause.id
+  end
+
+  private
+
+  def type(song)
+    if song.created_at == song.updated_at
+      PlaylistChannel::SONG_CREATED_TYPE
+    else
+      PlaylistChannel::SONG_UPDATED_TYPE
+    end
   end
 end

--- a/app/jobs/song_broadcast_job.rb
+++ b/app/jobs/song_broadcast_job.rb
@@ -1,0 +1,9 @@
+class SongBroadcastJob < ApplicationJob
+  queue_as :default
+
+  def perform(song)
+    ActionCable.server.broadcast PlaylistChannel::NAME,
+                                 type: PlaylistChannel::SONG_CREATED_TYPE,
+                                 song: song
+  end
+end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -6,13 +6,13 @@ class Song < ActiveRecord::Base
                      on_or_after: ->(t) { t.episode.beginning },
                      before: ->(_t) { Time.zone.now }
 
+  after_commit { SongBroadcastJob.perform_later self }
   after_create_commit :post_information_to_icecast
-  after_create_commit { SongBroadcastJob.perform_later self }
 
   scope :on_air, ->() { order(:at).last }
 
   def as_json(_options = {})
-    super(only: %i[name artist album label year request new local at])
+    super(only: %i[id name artist album label year request new local at])
   end
 
   def post_information_to_icecast

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -71,9 +71,11 @@
 
 <%= yield %>
 
+<% unless on_fm_computer? %>
 <div id="player-app" data-turbolinks-permanent />
 <%= javascript_pack_tag 'player' %>
 </div>
+<% end %>
 
 <% if Rails.env.production? %>
 <script>

--- a/app/views/playlist/_playlist.html.haml
+++ b/app/views/playlist/_playlist.html.haml
@@ -15,6 +15,13 @@
         %span Edit the playlist by clicking on the mistaken text.
         %i.dingbat✏︎
         %br
+  - else
+    %thead
+    %tbody
+      %tr.refresh-playlist
+        %td{colspan: 6}
+          The DJ has made some changes.
+          = link_to 'Click here to refresh the playlist.', root_path(anchor: 'now')
 
   %thead
     - unless @on_air.nil?

--- a/app/views/songs/_song.json.jbuilder
+++ b/app/views/songs/_song.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! song, :id, :name, :artist, :album, :label, :year, :request,
-              :local, :new, :at

--- a/app/views/songs/_song.json.jbuilder
+++ b/app/views/songs/_song.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! song,
-              :name, :artist, :album, :label, :year, :request, :local, :new, :at
+json.extract! song, :id, :name, :artist, :album, :label, :year, :request,
+              :local, :new, :at

--- a/app/views/songs/_song.json.jbuilder
+++ b/app/views/songs/_song.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! song,
+              :name, :artist, :album, :label, :year, :request, :local, :new, :at

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,10 +1,11 @@
 development:
-  adapter: async
+  adapter: redis
+  url: redis://localhost:6379/1
 
 test:
   adapter: async
 
 production:
   adapter: redis
-  url: redis://localhost:6379/1
+  url: <%= ENV["REDIS_URL"] %>
   channel_prefix: playlist_production

--- a/flow-typed/npm/actioncable_v5.x.x.js
+++ b/flow-typed/npm/actioncable_v5.x.x.js
@@ -1,0 +1,34 @@
+/**
+ * @flow
+ */
+
+declare class ActionCable$Consumer {
+  send(data: mixed): boolean;
+  connect(): boolean;
+  disconnect({ allowReconnect: boolean }): boolean;
+  ensureActiveConnection(): boolean;
+
+  subscriptions: ActionCable$Subscriptions;
+}
+
+declare class ActionCable$Subscription {
+  perform(action: string, data: Object): boolean;
+  send(data: Object): boolean;
+  unsubscribe(): void;
+
+  identifier: string; // Stringified JSON params
+}
+
+declare class ActionCable$Subscriptions {
+  create(
+    params: string | { channel: string },
+    mixin: { [string]: Function }
+  ): ActionCable$Subscription;
+}
+
+declare type ActionCable = {
+  [key: string]: ActionCable$Subscription,
+  cable: ActionCable$Consumer,
+}
+
+declare var App: ActionCable

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
+    "react-motion": "^0.5.2",
     "styled-components": "^2.2.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
+    "react-medium-image-zoom": "^3.0.5",
     "react-motion": "^0.5.2",
     "styled-components": "^2.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-react": "^6.10.3",
     "eslint-plugin-standard": "^2.3.1",
-    "flow-bin": "^0.59.0",
+    "flow-bin": "^0.61.0",
     "webpack-dev-server": "^2.9.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4716,7 +4716,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4, prop-types@^15.6.0:
+prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -4796,6 +4796,12 @@ querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
+raf@^3.1.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
+  dependencies:
+    performance-now "^2.1.0"
+
 rails-erb-loader@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/rails-erb-loader/-/rails-erb-loader-5.2.1.tgz#399b7781b88c129bc621a8256329ed2f855398e9"
@@ -4853,6 +4859,14 @@ react-dom@^16.2.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-motion@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.2.tgz#0dd3a69e411316567927917c6626551ba0607316"
+  dependencies:
+    performance-now "^0.2.0"
+    prop-types "^15.5.8"
+    raf "^3.1.0"
 
 react@^16.2.0:
   version "16.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4860,6 +4860,10 @@ react-dom@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-medium-image-zoom@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/react-medium-image-zoom/-/react-medium-image-zoom-3.0.5.tgz#fb8ef041a68c315a6d03a3b0667d88bbcbb22c33"
+
 react-motion@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.2.tgz#0dd3a69e411316567927917c6626551ba0607316"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2392,9 +2392,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.59.0.tgz#8c151ee7f09f1deed9bf0b9d1f2e8ab9d470f1bb"
+flow-bin@^0.61.0:
+  version "0.61.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.61.0.tgz#d0473a8c35dbbf4de573823f4932124397d32d35"
 
 for-in@^0.1.3:
   version "0.1.8"


### PR DESCRIPTION
This PR adds a song information display visible when the user is listening via the persistent player. It is automatically updated as the DJ adds songs to the playlist: in an `after_create_commit` callback, we use ActionCable to broadcast a `song_created` message which the player is listening for.