### PR TITLE
Fixes specialty show saving

### DIFF
--- a/app/models/specialty_show.rb
+++ b/app/models/specialty_show.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
 class SpecialtyShow < ActiveRecord::Base
   include Show
 
-  belongs_to :dj, class_name: "Dj", foreign_key: "coordinator_id"
+  belongs_to :dj, class_name: 'Dj', foreign_key: 'coordinator_id'
+
   has_and_belongs_to_many :djs, dependent: :delete_all
 
   alias_attribute :coordinator, :dj
@@ -14,22 +17,21 @@ class SpecialtyShow < ActiveRecord::Base
     :unassigned
   end
 
-  def dj_id_changed?
-    coordinator_id_changed?
+  def saved_change_to_dj_id?
+    saved_change_to_coordinator_id?
   end
 
   def deal
-    h = hosts
     # modify only unassigned or unconfirmed episodes
     unconfirmed_episodes = episodes.reject(&:past?).select do |x|
       x.unassigned? || x.normal?
     end
     unconfirmed_episodes.each_with_index do |ep, inx|
-      ep.dj = h[inx % h.count]
+      ep.dj = hosts[inx % hosts.count]
       ep.status = :normal
     end
 
-    transaction do 
+    transaction do
       unconfirmed_episodes.each(&:save!)
     end
   end
@@ -38,9 +40,7 @@ class SpecialtyShow < ActiveRecord::Base
     if hosts.count == 1
       "with #{dj}"
     else
-      h = hosts
-      "#{h.count} #{"DJ".pluralize(h.count)} in rotation"
+      "#{hosts.count} #{'DJ'.pluralize(hosts.count)} in rotation"
     end
   end
-
 end


### PR DESCRIPTION
The database column for a specialty show’s single DJ is
`coordinator_id`, but we were aliasing needed methods to `dj_id` to
conform to the Show interface. Forgot to `change dj_id_changed?` to
`saved_change_to_dj_id?`.