### PR TITLE
Fix IcecastUpdateJob

### DIFF
--- a/app/jobs/icecast_update_job.rb
+++ b/app/jobs/icecast_update_job.rb
@@ -23,7 +23,7 @@ class IcecastUpdateJob < ApplicationJob
   def icecast_endpoint(qual, song)
     mount = "/wcbn-#{qual}.mp3"
     'http://floyd.wcbn.org:8000/admin/metadata' \
-      "?mount=#{mount}&song=#{metadata_string(song)}" \
+      "?mount=#{mount}&song=#{Rack::Utils.escape metadata_string song}" \
       '&mode=updinfo'
   end
 


### PR DESCRIPTION
668aa87 (#36) broke the icecast update because I forgot that the song parameter needed to be URL escaped.