### PR TITLE
Reduce number of sidekiq workers not to exceed max clients

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -49,7 +49,7 @@ workers ENV.fetch('WEB_CONCURRENCY') { 2 }
 #
 on_worker_boot do
   if ENV['RAILS_ENV'] == 'production'
-    @sidekiq_pid ||= spawn('bundle exec sidekiq -c 10')
+    @sidekiq_pid ||= spawn('bundle exec sidekiq -c 3')
   end
 
   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)


### PR DESCRIPTION
Reduces to 3 sidekiq workers * 2 puma processes = 6 redis connections

We have a 20 connection maximum in the free redis plan on Heroku. While there is normally no problem to have 10 sidekiq workers * 2 puma processes, any other redis connection (whyever there might be one) blows up. We don’t need 20 workers for our limited background jobs. Let’s not walk so close to the edge.