### PR TITLE
Fix flaky fullfilled own request error

### DIFF
--- a/app/mailers/sub_request_mailer.rb
+++ b/app/mailers/sub_request_mailer.rb
@@ -1,46 +1,45 @@
-class SubRequestMailer < ApplicationMailer
+# frozen_string_literal: true
 
-  RADIO_NAMES = %w(radionauts radioteers radiologists radioland radioers
-  radioceans radiocopters radiofish radios radioists radiophones radioptics
-  radiologizers radiotizers radiosmiths radioramas)
+class SubRequestMailer < ApplicationMailer
+  RADIO_NAMES = %w[radionauts radioteers radiologists radioland radioers
+                   radioceans radiocopters radiofish radios radioists
+                   radiophones radioptics radiologizers radiotizers radiosmiths
+                   radioramas].freeze
 
   def request_of_group(sub_request)
     @sub_request = sub_request
     @dj = @sub_request.episode.dj
 
     mail to: @sub_request.requested_djs.map(&:name_and_email),
-      subject: "#{@sub_request.episode.dj} asked YOU to sub #{@sub_request.for}!"
+         subject: "#{@sub_request.episode.dj} asked YOU to sub #{@sub_request.for}!"
   end
 
   def request_of_all(sub_request)
     @sub_request = sub_request
     @dj = @sub_request.episode.dj
 
-    mail to: "Radio Free Ann Arbor <rfaa-mod@umich.edu>",
-      subject: "#{@sub_request.episode.dj} needs a sub #{@sub_request.for}!"
+    mail to: 'Radio Free Ann Arbor <rfaa-mod@umich.edu>',
+         subject: "#{@sub_request.episode.dj} needs a sub #{@sub_request.for}!"
   end
 
   def fulfilled(sub_request, asking_dj: nil)
     @sub_request = sub_request
     @fulfilling_dj = @sub_request.episode.dj
-    @asking_dj = if asking_dj.nil?
-                   @sub_request.episode.show.dj
-                 else
-                   asking_dj
-                 end
+    @asking_dj = asking_dj
+    @asking_dj ||= @sub_request.episode.show.dj
 
     attach_ical_event
 
     mail to: @asking_dj.name_and_email,
-      cc: @fulfilling_dj.name_and_email,
-      subject: "#{@fulfilling_dj} has taken your sub request #{@sub_request.for}"
+         cc: @fulfilling_dj.name_and_email,
+         subject: "#{@fulfilling_dj} has taken your sub request #{@sub_request.for}"
   end
 
   def unfulfilled(sub_request)
     @sub_request = sub_request
     @dj = @sub_request.episode.dj
 
-    mail to: @dj.name_and_email, subject: "Your sub request for tomorrow is still unclaimed!"
+    mail to: @dj.name_and_email, subject: 'Your sub request for tomorrow is still unclaimed!'
   end
 
   def reminder(sub_request)

--- a/app/models/sub_request.rb
+++ b/app/models/sub_request.rb
@@ -18,8 +18,7 @@ class SubRequest < ActiveRecord::Base
 
   before_create :ensure_group_is_not_sparse
   before_create :set_status_from_request_group
-  after_create :send_emails
-  after_update :send_emails
+  after_save :send_emails
   after_save :update_episode_status
   after_destroy :reset_episode_status
 
@@ -33,12 +32,10 @@ class SubRequest < ActiveRecord::Base
 
   def send_emails
     case status.to_sym
-    when :needs_sub then SubRequestMailer.request_of_all(self).deliver_later
+    when :needs_sub then
+      SubRequestMailer.request_of_all(self).deliver_later
     when :needs_sub_in_group then
       SubRequestMailer.request_of_group(self).deliver_later
-    when :confirmed
-      asking_dj = Dj.find(episode.dj_id_previous_change.first)
-      SubRequestMailer.fulfilled(self, asking_dj: asking_dj).deliver_later
     end
   end
 

--- a/app/models/sub_request/fulfillment.rb
+++ b/app/models/sub_request/fulfillment.rb
@@ -4,9 +4,11 @@ class SubRequest
   # A Fulfillment is when a DJ takes another DJ’s slot in response to a
   # SubRequest.
   class Fulfillment
-    def initialize(sub_request, dj)
+    def initialize(sub_request, fulfilling_dj)
       @sub_request = sub_request
-      @dj = dj
+
+      @asking_dj = sub_request.episode.dj
+      @fulfilling_dj = fulfilling_dj
 
       set_attributes
     end
@@ -16,13 +18,20 @@ class SubRequest
         @sub_request.episode.save
         @sub_request.save
       end
+
+      send_confirmation_email
     end
 
     private
 
     def set_attributes
       @sub_request.status = :confirmed
-      @sub_request.episode.dj = @dj
+      @sub_request.episode.dj = @fulfilling_dj
+    end
+
+    def send_confirmation_email
+      SubRequestMailer.fulfilled(@sub_request, asking_dj: @asking_dj)
+                      .deliver_later
     end
   end
 end

--- a/spec/system/requesting_a_sub_spec.rb
+++ b/spec/system/requesting_a_sub_spec.rb
@@ -1,6 +1,12 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'Requesting a sub' do
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
   it 'works' do
     asking_dj = create :dj, :grandfathered_in
     fulfilling_dj = create :dj, :grandfathered_in


### PR DESCRIPTION
Relying on ActiveModel::Dirty is flaky. Maybe it’s a race condition.
Maybe it’s about threads. IDK but sending the confirmation email from
SubRequest::Fulfillment, after storing asking and fulfilling djs
explicitly, instead of relying on the previous change record in the
callback to SubRequest#after_save should probably fix it.