### PR TITLE
remove js player widget

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -76,12 +76,6 @@
 
 <%= yield %>
 
-<% unless on_fm_computer? %>
-<div id="player-app" data-turbolinks-permanent />
-<%= javascript_pack_tag 'player' %>
-</div>
-<% end %>
-
 <% if Rails.env.production? %>
 <script>
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
modern browsers block secure (https) resources from accessing insecure (http) resources e.g. images, our broadcast audio etc.